### PR TITLE
Added a line about a Linux-related problem on the "Unable to set up prerequisites for package" section of Troubleshoot.md

### DIFF
--- a/Troubleshoot.md
+++ b/Troubleshoot.md
@@ -79,6 +79,8 @@ a HTTP Protocol error on the serving point.  In case of the RPS v2, if it occurs
 If you get the error message from any other package sender, this is due
 the lack of missing multipart stream support.  
 
+If you are on Linux, you may need to run the app as `sudo` as you may lack permissions to the ports for serving.
+
 ## My RPI crashes on console  
 This happend to a couple of users when we try to hit RPI too hard.    
 RPI cann't handle too many concurrent requests and crashes after a while    


### PR DESCRIPTION
The "Unable to set up prerequisites for package" error can be solved by changing the port, but if you don't have permissions to access the ports, it does nothing to help you. In some cases, you may need to run the app as `sudo` so the program itself can have the permissions to serve. That's what solved for me as changing ports would do nothing.

I'm not sure what would be the optimal solution for dealing with this on the app. Maybe asking for the admin password when starting the server (can you even do that in a webapp like this? I don't think so).

For now, simply running the app as `sudo` fixes the problem on Linux.